### PR TITLE
Display edition Of tiles in map editor

### DIFF
--- a/assets/manifests/tiles.json
+++ b/assets/manifests/tiles.json
@@ -1,7 +1,7 @@
 {
 	"path":"assets/tiles/Redux/",
 	"manifest": [
-		{"id":"Tile-Abyz-Fria", "src":"AbyzFria.png", "planets": [
+		{"id":"Tile-Abyz-Fria", "src":"AbyzFria.png", "edition": "TI3", "planets": [
 			{"name":"Abyz"}
 			,{"name":"Fria"}
 		]},

--- a/lib/GameObjects-0.3.js
+++ b/lib/GameObjects-0.3.js
@@ -91,6 +91,7 @@
 		this.q = obj.q;
 		this.r = obj.r;
 		this.clonedFrom = obj.clonedFrom || this;
+		this.edition = obj.edition || 'SA';
 
 		/*
 		var hexagon = new createjs.Shape();

--- a/lib/PanelContainer-0.3.js
+++ b/lib/PanelContainer-0.3.js
@@ -442,7 +442,9 @@
 			var col = 0;
 			var tile;
 			var rect;
+			var text;
 			
+
 			for (var num = 0; num < container.tiles.length; num++) {
 				tile = container.tiles[num];
 				rect = new createjs.Shape();
@@ -452,6 +454,13 @@
 				tile.x = 2*offset + col*(tileWidth+3*offset) +tileWidth/2;
 				tile.y = 2*offset + row*(tileHeight+3*offset) +tileHeight/2;
 				tile.parentPanel = container;
+
+				if(tile.edition){
+					text = new createjs.Text(a.edition, "60px Arial", "#FFF");
+					text.x = 2*offset + col*(tileWidth+3*offset) ;
+					text.y = 2*offset + row*(tileHeight+3*offset) +tileHeight;
+					container.addChild(text);
+				}
 
 				container.addChild(rect, tile);
 


### PR DESCRIPTION
My proposal would be to add a edition property in the tiles.json manifest

```json
{
	"path":"assets/tiles/Redux/",
	"manifest": [
		{"id":"Tile-Abyz-Fria", "src":"AbyzFria.png", "edition": "TI3", "planets": [
			{"name":"Abyz"}
			,{"name":"Fria"}
		]},
                //...
        ]
}
```

I managed to render it in the tiles panel

![image](https://user-images.githubusercontent.com/389101/147647548-df3cf5d8-c65c-4180-b89c-1e77d36c7e88.png)

The current implementation shows the edition if set, and `SA` otherwise. So every tile not belonging to an edition would automaticly be a SA exclusive tile.

It should also be possible to display add all edditions required for the current map by iterating over all tiles used.

What I don't know is how the file TI3SA-0.1.js gets generated it looks like a minified version of some other files, but I havn't seen documentation how to generate it. Thats why this pull request is not correctly working. I have added the minified version localy to reproduce my changes to veryfiy them. But I think it is unrewarding to commit those changes.

I also hope this is the correct version, since it looks a bit different then the deployed one.